### PR TITLE
Remove page number from cover

### DIFF
--- a/template/covers.typ
+++ b/template/covers.typ
@@ -72,6 +72,7 @@
     (authors + author_id,)
   }
 
+  set page("a4", numbering: none)
   align(left)[
     #image("assets/hdu.png", width: 60%)
   ]


### PR DESCRIPTION
Starting numbering from the contents page (page 2) is the usual convention.

<img width="761" height="1192" alt="effect" src="https://github.com/user-attachments/assets/9a93ed76-e85b-41ff-aa38-013f0923d8bf" />
